### PR TITLE
Add video poster/thumbnail generation from first frame

### DIFF
--- a/src/components/TikTokVideos.tsx
+++ b/src/components/TikTokVideos.tsx
@@ -18,6 +18,7 @@ const videos: VideoItem[] = [
 export default function TikTokVideos() {
     const videoRefs = useRef<(HTMLVideoElement | null)[]>([]);
     const [playingStates, setPlayingStates] = useState<boolean[]>(videos.map(() => false));
+    const [posterUrls, setPosterUrls] = useState<string[]>(videos.map(() => ''));
 
     const playVideo = (index: number) => {
         const video = videoRefs.current[index];
@@ -81,6 +82,31 @@ export default function TikTokVideos() {
         }
     };
 
+    const generatePoster = (index: number) => {
+        const video = videoRefs.current[index];
+        if (!video || posterUrls[index]) return; // Skip if already generated
+
+        try {
+            const canvas = document.createElement('canvas');
+            canvas.width = video.videoWidth;
+            canvas.height = video.videoHeight;
+            const ctx = canvas.getContext('2d');
+
+            if (ctx) {
+                ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+                const posterUrl = canvas.toDataURL('image/jpeg', 0.8);
+
+                setPosterUrls(prev => {
+                    const newUrls = [...prev];
+                    newUrls[index] = posterUrl;
+                    return newUrls;
+                });
+            }
+        } catch (err) {
+            console.error('Failed to generate poster:', err);
+        }
+    };
+
     return (
         <section className={styles.tiktokSection}>
             <div className={styles.container}>
@@ -102,10 +128,11 @@ export default function TikTokVideos() {
                                     ref={(el) => { videoRefs.current[index] = el; }}
                                     className={styles.video}
                                     src={video.src}
-                                    poster={video.poster}
+                                    poster={posterUrls[index] || video.poster}
                                     loop
                                     playsInline
                                     preload="metadata"
+                                    onLoadedData={() => generatePoster(index)}
                                 />
                                 {!playingStates[index] && (
                                     <div className={styles.playOverlay}>


### PR DESCRIPTION
Automatically extract and display the first frame of each video as a poster image. This ensures video thumbnails are visible on mobile devices before playback.

Changes:
- Added posterUrls state to store generated poster images
- Created generatePoster function to extract first frame using canvas
- Added onLoadedData handler to trigger poster generation
- Poster images are generated as base64 JPEG data URLs
- Fallback to video.poster if extraction fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Videos now automatically generate and display custom poster images from video content.
  * Posters are generated on-demand as each video loads.
  * Falls back to original poster if automatic generation is unavailable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->