### PR TITLE
Fix app store badge alignment on mobile

### DIFF
--- a/src/components/DownloadCTA.module.css
+++ b/src/components/DownloadCTA.module.css
@@ -57,11 +57,19 @@
 }
 
 .storeBadgeImage {
-  height: 75px;
+  height: 60px;
   width: auto;
+  max-width: 180px;
   transition: transform var(--transition-fast), filter var(--transition-fast),
     box-shadow var(--transition-fast);
   cursor: pointer;
+}
+
+@media (min-width: 768px) {
+  .storeBadgeImage {
+    height: 75px;
+    max-width: 225px;
+  }
 }
 
 .storeBadgeImage:hover {


### PR DESCRIPTION
- Reduce badge height on mobile from 75px to 60px for better fit
- Add max-width constraints (180px mobile, 225px desktop) to ensure consistent sizing
- Both badges now maintain aspect ratios while staying within consistent bounds
- Improves visual alignment and centering on mobile devices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized store badge image sizing across devices with responsive breakpoints, reducing default height on smaller screens while maintaining full dimensions on larger viewports for improved visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->